### PR TITLE
Allow only owner edit

### DIFF
--- a/src/Entity/DragonTreasure.php
+++ b/src/Entity/DragonTreasure.php
@@ -15,7 +15,6 @@ use Carbon\Carbon;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use ApiPlatform\Metadata\Get;
-use ApiPlatform\Metadata\Put;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Patch;
@@ -38,11 +37,10 @@ use Symfony\Component\Validator\Constraints as Assert;
         new Post(
             security: 'is_granted("ROLE_TREASURE_CREATE")'
         ),
-        new Put(
-            security: 'is_granted("ROLE_TREASURE_EDIT")'
-        ),
         new Patch(
-            security: 'is_granted("ROLE_TREASURE_EDIT")'
+            security: 'is_granted("ROLE_TREASURE_EDIT") and object.getOwner() == user',
+            // vérifie que le owner est toujours l'utilisateur connecter apres modification
+            securityPostDenormalize: 'object.getOwner() == user'
         ),
         new Delete(
             security: 'is_granted("ROLE_ADMIN")'

--- a/tests/Functional/DragonTreasureResourceTest.php
+++ b/tests/Functional/DragonTreasureResourceTest.php
@@ -98,4 +98,47 @@ class DragonTreasureResourceTest extends ApiTestCase
             ->assertStatus(403)
         ;
     }
+
+    public function testPatchToUpdateTreasureByOwner(): void
+    {
+        $user = UserFactory::createOne();
+        $treasure = DragonTreasureFactory::createOne(['owner' => $user]);
+
+        $this->browser()
+            ->actingAs($user)
+            ->patch('/api/treasures/' . $treasure->getId(), [
+                'json' => [
+                    'value' => 12345
+                ]
+            ])
+            ->assertStatus(200)
+            ->assertJsonMatches('value', 12345);
+
+        $user2 = UserFactory::createOne();
+        $this->browser()
+            ->actingAs($user2)
+            ->patch('/api/treasures/' . $treasure->getId(), [
+                'json' => [
+                    'value' => 6789
+                ]
+            ])
+            ->assertStatus(403);
+    }
+
+    public function testPatchToUpdateOwnerTreasure(): void
+    {
+        $user = UserFactory::createOne();
+        $user2 = UserFactory::createOne();
+        $treasure = DragonTreasureFactory::createOne(['owner' => $user]);
+
+        $this->browser()
+            ->actingAs($user)
+            ->patch('/api/treasures/' . $treasure->getId(), [
+                'json' => [
+                    // change the owner to someone else blocked by securityPostDenormalize
+                    'owner' => '/api/users/'. $user2->getId()
+                ]
+            ])
+            ->assertStatus(403);
+    }
 }


### PR DESCRIPTION
Feature:

- Empêche un utilisateur à modifier le trésor d'un autre utilisateur si il n'est pas le propriétaire du trésor., grâce au composant "security" voir  l'expression régulière : "object.getOwner() == user"
- Empêche  le propriétaire d'un trésor à attribuer un trésor à un autre utilisateur. Voir "securityPostDenormalize" qui vérifie qu'après la dénormalization le propriétaire du trésor est toujours l'utilisateur authentifié.